### PR TITLE
Fix schedule duplication tooltip syntax error

### DIFF
--- a/sprinkler.py
+++ b/sprinkler.py
@@ -1194,7 +1194,7 @@ function updateSchedules(schedules){
     dup.className = 'btn';
     dup.textContent = 'Duplicate';
     dup.style.marginLeft = '8px';
-    dup.title = 'Make a copy that starts at this schedule\'s OFF time with the same duration';
+    dup.title = "Make a copy that starts at this schedule's OFF time with the same duration";
     dup.addEventListener('click', (function(sRef){
       return function(){
         var onM  = parseHHMM(sRef.on);


### PR DESCRIPTION
## Summary
- Escape apostrophe in schedule duplication tooltip to prevent JavaScript syntax error that blocked pin rendering

## Testing
- `python -m py_compile sprinkler.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9c9cbafdc833197bc4982f421cb1c