### PR TITLE
Close renderPinsGrouped function

### DIFF
--- a/sprinkler.py
+++ b/sprinkler.py
@@ -1092,6 +1092,7 @@ function startCountdown(pin, seconds){
     }
   }, 1000);
 }
+}
 /* ========= Schedules ========= */
 function updateSchedules(schedules){
   var tbody = document.getElementById('schedBody');


### PR DESCRIPTION
## Summary
- fix unexpected end of input in inline script by closing `renderPinsGrouped`

## Testing
- `python -m py_compile sprinkler.py`
- `node --check script.js && echo 'syntax ok'`


------
https://chatgpt.com/codex/tasks/task_e_68b9d2bf33d883319a000f91d540982c