### PR TITLE
Handle invalid numeric day tokens in parse_days

### DIFF
--- a/sprinkler.py
+++ b/sprinkler.py
@@ -2130,6 +2130,8 @@ def parse_days(day_str: str) -> List[int]:
             v = int(p)
             if 0 <= v <= 6:
                 out.append(v)
+            else:
+                raise ValueError(f"Unknown day token: {p}")
         else:
             try:
                 idx = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"].index(p[:3])

--- a/tests/test_parse_days.py
+++ b/tests/test_parse_days.py
@@ -1,0 +1,11 @@
+import pytest
+from sprinkler import parse_days
+
+
+def test_parse_days_valid_numeric():
+    assert parse_days("1,5") == [1, 5]
+
+
+def test_parse_days_invalid_numeric():
+    with pytest.raises(ValueError):
+        parse_days("8")


### PR DESCRIPTION
## Summary
- raise `ValueError` when numeric day tokens fall outside 0-6
- add unit tests for `parse_days`

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9df2e83f88331af921c4f9128150d