### PR TITLE
feat: enable drag reorder for pins and schedules

### DIFF
--- a/tests/test_reorder.py
+++ b/tests/test_reorder.py
@@ -1,0 +1,45 @@
+import tempfile
+import sprinkler
+import pytest
+
+pytest.importorskip("flask")
+
+sprinkler.CONFIG_PATH = tempfile.NamedTemporaryFile(delete=False).name
+
+
+def build_app():
+    cfg = {
+        "pins": {
+            "5": {"name": "Slot 1"},
+            "6": {"name": "Slot 2"},
+        },
+        "schedules": [
+            {"id": "a", "pin": 5, "on": "06:00", "off": "06:30", "days": [0], "enabled": True},
+            {"id": "b", "pin": 6, "on": "07:00", "off": "07:30", "days": [1], "enabled": True},
+        ],
+        "automation_enabled": True,
+    }
+    pinman = sprinkler.PinManager(cfg)
+    sched = sprinkler.SprinklerScheduler(pinman, cfg)
+    sched.reload_jobs = lambda: None
+    app = sprinkler.build_app(cfg, pinman, sched)
+    app.testing = True
+    return app, cfg
+
+
+def test_reorder_schedules():
+    app, cfg = build_app()
+    client = app.test_client()
+    resp = client.post('/api/schedules/reorder', json={"order": ["b", "a"]})
+    assert resp.status_code == 200
+    assert [s["id"] for s in cfg["schedules"]] == ["b", "a"]
+
+
+def test_reorder_pins():
+    app, cfg = build_app()
+    client = app.test_client()
+    resp = client.post('/api/pins/reorder', json={"order": [6, 5]})
+    assert resp.status_code == 200
+    assert list(cfg["pins"].keys()) == ["6", "5"]
+    assert cfg["pins"]["6"]["order"] == 0
+    assert cfg["pins"]["5"]["order"] == 1


### PR DESCRIPTION
## Summary
- support drag-and-drop ordering of pins and schedules in UI
- persist pin and schedule order via new API endpoints
- add tests for reordering logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9e5849c408331a0b5dd1ed8cdc16f