### PR TITLE
Ensure settings section becomes visible on button click

### DIFF
--- a/sprinkler.py
+++ b/sprinkler.py
@@ -1437,7 +1437,10 @@ function setupDayDropdown(){
     });
 
     document.getElementById('settingsBtn').addEventListener('click', ()=>{
-      document.getElementById('settingsCard').classList.toggle('open');
+      const card = document.getElementById('settingsCard');
+      const willOpen = !card.classList.contains('open');
+      card.classList.toggle('open');
+      if(willOpen){ card.scrollIntoView({behavior:'smooth', block:'start'}); }
     });
     document.getElementById('saveSettings').addEventListener('click', ()=>{
       const m = parseInt(document.getElementById('defManualMins').value,10);


### PR DESCRIPTION
## Summary
- Scroll the Settings card into view when the header Settings button is pressed
- Open the card only once so the scroll happens on expansion

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb99b4d3ec83318d0814f9c6831459