### PR TITLE
Ensure embedded UI initializes after DOM ready

### DIFF
--- a/sprinkler.py
+++ b/sprinkler.py
@@ -1377,7 +1377,7 @@ function sequenceSchedules(){
     sum.textContent = 'Enabled: ' + (en && en.checked ? 'Yes' : 'No') + ' • Threshold: ' + (th ? th.value : thr) + '%';
   }
 }
-document.addEventListener('DOMContentLoaded', ()=>{
+function init(){
   // Theme toggle
   const themeBtn = document.getElementById('themeToggle');
   if(themeBtn){
@@ -1453,7 +1453,13 @@ document.getElementById('deleteAllSchedules')?.addEventListener('click', ()=>{
   // Kick off
   fetchStatus();
   setInterval(fetchStatus, 60000);
-});
+}
+
+if(document.readyState === 'loading'){
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Wrap embedded web UI bootstrapping code in an init() function
- Run init() immediately when the DOM is already loaded or after `DOMContentLoaded`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc548f40248331bd666f71caf79990