### PR TITLE
Allow configuring web host via SPRINKLER_HOME

### DIFF
--- a/sprinkler.py
+++ b/sprinkler.py
@@ -1988,6 +1988,14 @@ web host/port and tweak the NTP server.  Manual schedules and
 presets are stored here too.  After editing, restart the controller
 or reapply the relevant preset.
 
+An alternate host can be supplied at runtime by setting the
+SPRINKLER_HOME environment variable.  For example:
+
+  export SPRINKLER_HOME=sprinkler.home
+
+This overrides the host used when running `web` without editing the
+configuration file.
+
 """)
 
 
@@ -2005,7 +2013,8 @@ def main():
 
     # web command
     p_web = sub.add_parser("web", help="Run web UI and scheduler")
-    p_web.add_argument("--host", default=cfg.get("web", {}).get("host", "0.0.0.0"))
+    default_host = os.environ.get("SPRINKLER_HOME", cfg.get("web", {}).get("host", "0.0.0.0"))
+    p_web.add_argument("--host", default=default_host)
     p_web.add_argument("--port", type=int, default=int(cfg.get("web", {}).get("port", 8000)))
 
     # status command

--- a/tests/test_env_host.py
+++ b/tests/test_env_host.py
@@ -1,0 +1,27 @@
+import sys
+import sprinkler
+
+
+def test_env_host_overrides_default(monkeypatch, tmp_path):
+    # ensure config path is temp
+    sprinkler.CONFIG_PATH = str(tmp_path / 'config.json')
+    # environment variable specifying host
+    monkeypatch.setenv("SPRINKLER_HOME", "sprinkler.home")
+
+    captured = {}
+
+    class DummyApp:
+        def run(self, host=None, port=None):
+            captured['host'] = host
+            captured['port'] = port
+
+    # use dummy app
+    monkeypatch.setattr(sprinkler, "build_app", lambda cfg, p, s, r: DummyApp())
+    # prevent scheduler from starting threads
+    monkeypatch.setattr(sprinkler.SprinklerScheduler, "start", lambda self: None)
+
+    # run main with web command
+    monkeypatch.setattr(sys, "argv", ["sprinkler.py", "web"])
+    sprinkler.main()
+
+    assert captured['host'] == "sprinkler.home"


### PR DESCRIPTION
## Summary
- make web command honour `SPRINKLER_HOME` environment variable
- document environment variable for overriding host
- add test verifying host override behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf0ea068408331b96212cda28c33d5