### PR TITLE
Add pin name settings page and hide GPIO numbers

### DIFF
--- a/tests/test_settings_page.py
+++ b/tests/test_settings_page.py
@@ -1,0 +1,37 @@
+import tempfile
+
+import sprinkler
+import pytest
+
+
+pytest.importorskip("flask")
+
+
+sprinkler.CONFIG_PATH = tempfile.NamedTemporaryFile(delete=False).name
+
+
+def build_app():
+    cfg = {
+        "pins": {
+            "5": {"name": "Front"},
+            "6": {"name": "Back"},
+        },
+        "schedules": [],
+        "automation_enabled": True,
+    }
+    pinman = sprinkler.PinManager(cfg)
+    sched = sprinkler.SprinklerScheduler(pinman, cfg)
+    sched.reload_jobs = lambda: None
+    app = sprinkler.build_app(cfg, pinman, sched)
+    app.testing = True
+    return app, cfg
+
+
+def test_settings_lists_pins():
+    app, _ = build_app()
+    client = app.test_client()
+    resp = client.get('/settings')
+    assert resp.status_code == 200
+    body = resp.data.decode()
+    assert "Pin Names" in body
+

--- a/tests/test_settings_page.py
+++ b/tests/test_settings_page.py
@@ -34,4 +34,18 @@ def test_settings_lists_pins():
     assert resp.status_code == 200
     body = resp.data.decode()
     assert "Pin Names" in body
+    # The settings page loads pins dynamically; verify the API supplies
+    # each GPIO with its configured name so the page can render them.
+    status = client.get('/api/status').get_json()
+    assert any(p["pin"] == 5 and p["name"] == "Front" for p in status["pins"])
+    assert any(p["pin"] == 6 and p["name"] == "Back" for p in status["pins"])
+
+
+def test_dashboard_hides_gpio_numbers():
+    app, _ = build_app()
+    client = app.test_client()
+    resp = client.get('/')
+    assert resp.status_code == 200
+    body = resp.data.decode()
+    assert 'GPIO' not in body
 


### PR DESCRIPTION
## Summary
- add a dedicated `/settings` page to edit pin names by GPIO
- hide GPIO numbers from the main dashboard and dropdowns
- default pins without names to `Unnamed`
- test settings page route

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf0ef266f883319e7d9ae9e4386d08