### PR TITLE
Add settings page for pin names

### DIFF
--- a/tests/test_settings_page.py
+++ b/tests/test_settings_page.py
@@ -1,0 +1,34 @@
+import tempfile
+import sprinkler
+import pytest
+
+pytest.importorskip("flask")
+
+sprinkler.CONFIG_PATH = tempfile.NamedTemporaryFile(delete=False).name
+
+
+def build_app():
+    cfg = {
+        "pins": {
+            "5": {"name": "Slot 1"},
+            "6": {"name": "Slot 2"},
+        },
+        "schedules": [],
+        "automation_enabled": True,
+    }
+    pinman = sprinkler.PinManager(cfg)
+    sched = sprinkler.SprinklerScheduler(pinman, cfg)
+    sched.reload_jobs = lambda: None
+    app = sprinkler.build_app(cfg, pinman, sched)
+    app.testing = True
+    return app
+
+
+def test_settings_lists_pins():
+    app = build_app()
+    client = app.test_client()
+    resp = client.get('/settings')
+    assert resp.status_code == 200
+    text = resp.data.decode()
+    assert 'GPIO 5' in text
+    assert 'Slot 1' in text


### PR DESCRIPTION
## Summary
- Add dedicated settings page with editable pin names listed by GPIO
- Link settings from main UI and display pin labels without GPIO numbers
- Provide tests for settings page endpoint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf143606748331af0b52913472626b