### PR TITLE
Redirect root URL to settings

### DIFF
--- a/sprinkler.py
+++ b/sprinkler.py
@@ -135,7 +135,7 @@ except Exception:
 # Web (Flask)
 # =========================
 try:
-    from flask import Flask, jsonify, request, Response  # type: ignore
+    from flask import Flask, jsonify, request, Response, redirect  # type: ignore
 except Exception:
     # Provide minimal stubs when Flask is not installed.  The web
     # interface will not be available, but the CLI can still be used
@@ -157,6 +157,8 @@ except Exception:
             print("Flask app would run on", host, port)
     def jsonify(obj):
         return obj
+    def redirect(location, code=302):
+        return location
     # Simulate Flask request with args and get_json method
     class _Request:
         def __init__(self):
@@ -1501,7 +1503,7 @@ if(document.readyState === 'loading'){
 
     @app.get("/")
     def index():
-        return Response("<p>See <a href='/settings'>settings</a></p>", mimetype="text/html")
+        return redirect("/settings")
 
     @app.get("/settings")
     def settings_page():

--- a/tests/test_settings_page.py
+++ b/tests/test_settings_page.py
@@ -33,6 +33,15 @@ def test_settings_serves_main_ui():
     assert 'Sprinkler Controller' in text
 
 
+def test_root_redirects_to_settings():
+    app = build_app()
+    client = app.test_client()
+    resp = client.get('/')
+    assert resp.status_code == 302
+    # Flask may include full URL in Location; ensure it ends with /settings
+    assert resp.headers['Location'].endswith('/settings')
+
+
 def test_pin_settings_lists_pins():
     app = build_app()
     client = app.test_client()


### PR DESCRIPTION
## Summary
- redirect root path to settings page for easier access
- support redirect import with fallback stub when Flask missing
- test homepage redirect

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf8b7648f48331a3ef6810c3ae41dd