### PR TITLE
feat: allow domain override via env

### DIFF
--- a/sprinkler.py
+++ b/sprinkler.py
@@ -2051,11 +2051,12 @@ presets are stored here too.  After editing, restart the controller
 or reapply the relevant preset.
 
 An alternate host can be supplied at runtime by setting the
-SPRINKLER_HOME environment variable.  For example:
+``SPRINKLER_DOMAIN`` environment variable.  For example:
 
-  export SPRINKLER_HOME=sprinkler.home
+  export SPRINKLER_DOMAIN=sprinkler.buell
 
-This overrides the host used when running `web` without editing the
+The legacy ``SPRINKLER_HOME`` variable is still honoured.  Either one
+overrides the host used when running ``web`` without editing the
 configuration file.
 
 """)
@@ -2075,7 +2076,9 @@ def main():
 
     # web command
     p_web = sub.add_parser("web", help="Run web UI and scheduler")
-    default_host = os.environ.get("SPRINKLER_HOME", cfg.get("web", {}).get("host", "0.0.0.0"))
+    default_host = os.environ.get("SPRINKLER_DOMAIN") or os.environ.get(
+        "SPRINKLER_HOME", cfg.get("web", {}).get("host", "0.0.0.0")
+    )
     p_web.add_argument("--host", default=default_host)
     p_web.add_argument("--port", type=int, default=int(cfg.get("web", {}).get("port", 8000)))
 

--- a/tests/test_env_host.py
+++ b/tests/test_env_host.py
@@ -1,12 +1,14 @@
 import sys
+import pytest
 import sprinkler
 
 
-def test_env_host_overrides_default(monkeypatch, tmp_path):
+@pytest.mark.parametrize("env_name", ["SPRINKLER_HOME", "SPRINKLER_DOMAIN"])
+def test_env_host_overrides_default(monkeypatch, tmp_path, env_name):
     # ensure config path is temp
     sprinkler.CONFIG_PATH = str(tmp_path / 'config.json')
     # environment variable specifying host
-    monkeypatch.setenv("SPRINKLER_HOME", "sprinkler.home")
+    monkeypatch.setenv(env_name, "sprinkler.buell")
 
     captured = {}
 
@@ -24,4 +26,4 @@ def test_env_host_overrides_default(monkeypatch, tmp_path):
     monkeypatch.setattr(sys, "argv", ["sprinkler.py", "web"])
     sprinkler.main()
 
-    assert captured['host'] == "sprinkler.home"
+    assert captured['host'] == "sprinkler.buell"


### PR DESCRIPTION
## Summary
- support `SPRINKLER_DOMAIN` env var to override web host
- document using `SPRINKLER_DOMAIN` for custom hostname like `sprinkler.buell`
- expand env host test to cover new variable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c02748d2988331bdc75d95c7ca2ecd